### PR TITLE
toString now sorts the params before creating the string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # query-parse
 
-Parse query strings to objects and objects to strings. USEFUL: Removes null or empty values.
+Parse query strings to objects and objects to strings.
+
+USEFUL: Removes null or empty values. It also sorts the params alphabetically, so you will always get the same string for the same params.
 
 ## Install
 
@@ -20,7 +22,7 @@ var paramStr = qp.toString({
 
 var paramObj = qp.toObject('param1=foo&param2=bar&param3=');
 
-// Outputs: 
+// Outputs:
 //  {
 //    param1: 'foo',
 //    param2: 'bar'

--- a/index.js
+++ b/index.js
@@ -1,21 +1,20 @@
 var querystring = require('querystring');
+var toPairs = require('lodash/toPairs');
 
 var qp = {
   toString: function (params) {
     var str = '';
-    Object.keys(params).forEach(function (key) {
-      if (params[key] !== undefined) {
-        if (str !== '') {
-          str += '&';
-        }
-        
-        str += key + '=' + encodeURIComponent(params[key]);
-      }
-    });
-    
+    toPairs(params)
+      .sort(function(a, b) { return a[0] > b[0]; })
+      .map(function(param) {
+          if (param[1] !== undefined) {
+              if (str !== '') str += '&';
+              str += param[0] + '=' + encodeURIComponent(param[1]);
+          }
+      });
     return str;
   },
-  
+
   toObject: function (str) {
     return querystring.parse(str);
   }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "license": "MIT",
   "devDependencies": {
     "tape": "~1.0.4"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,10 @@ var _obj = {
   param1: 'yes',
   param2: 'no'
 };
+var _obj2 = {
+  param2: 'no',
+  param1: 'yes'
+};
 
 test('To String', function (t) {
   t.plan(1);
@@ -14,4 +18,9 @@ test('To String', function (t) {
 test('To Object', function (t) {
   t.plan(1);
   t.deepEqual(qp.toObject(_str), _obj, 'Converts a query string to an object');
+});
+
+test('To String (sorted)', function(t) {
+  t.plan(1);
+  t.deepEqual(qp.toString(_obj), qp.toString(_obj2), 'Both strings should be equal');
 });


### PR DESCRIPTION
Thanks for your work here @scottcorgan.

We need that each object creates always the same string, without being affected by the random order of `forEach` so I modified your `toString` function.

If you prefer not to accept this PR please let me know and I will create our own package `sorted-query-parse`.